### PR TITLE
lpy.el: Fix heading regexps

### DIFF
--- a/lpy.el
+++ b/lpy.el
@@ -69,10 +69,10 @@
 
 (defconst lpy-font-lock-keywords
   '(("^# ?\\(\\*\\|\\*[^*\n].*\\)$" 1 'org-level-1 prepend)
-    ("^# ?\\(\\*\\*[^*\n]?.*\\)$" 1 'org-level-2 prepend)
-    ("^# ?\\(\\*\\*\\*[^*\n]?.*\\)$" 1 'org-level-3 prepend)
-    ("^# ?\\(\\*\\*\\*\\*[^*\n]?.*\\)$" 1 'org-level-4 prepend)
-    ("^# ?\\(\\*\\*\\*\\*\\*[*\n]?.*\\)$" 1 'org-level-5 prepend)
+    ("^# ?\\(\\*\\{2\\}\\|\\*\\{2\\}[^*\n].*\\)$" 1 'org-level-2 prepend)
+    ("^# ?\\(\\*\\{3\\}\\|\\*\\{3\\}[^*\n].*\\)$" 1 'org-level-3 prepend)
+    ("^# ?\\(\\*\\{4\\}\\|\\*\\{4\\}[^*\n].*\\)$" 1 'org-level-4 prepend)
+    ("^# ?\\(\\*\\{5\\}\\|\\*\\{5\\}[^*\n].*\\)$" 1 'org-level-5 prepend)
     (lpy-outline-comment-highlight 1 'default prepend)
     ;; ("^#  \\([^ ].*\\)$" 1 'default prepend)
     ("`\\([^\n']+\\)'" 1 font-lock-constant-face prepend)))


### PR DESCRIPTION
Fix the issue that level n regexp also matches level n+1 headings.